### PR TITLE
helpers: Add Injected property wrapper

### DIFF
--- a/Sources/Octoseer/Helpers/Injected.swift
+++ b/Sources/Octoseer/Helpers/Injected.swift
@@ -1,0 +1,9 @@
+@propertyWrapper
+struct Injected<Value> {
+
+    private(set) var wrappedValue: Value
+
+    init() {
+        wrappedValue = AppAssembly.shared.resolve(Value.self)
+    }
+}

--- a/Sources/Octoseer/Services/PluginService/PluginService.swift
+++ b/Sources/Octoseer/Services/PluginService/PluginService.swift
@@ -17,11 +17,12 @@ struct Trial {
 
 class PluginService {
 
-    private lazy var configuration: ConfigurationData = {
-        let configurationProvider = AppAssembly.shared.resolve(ConfigurationProvider.self)
+    @Injected
+    private var configurationProvider: ConfigurationProvider
 
+    private var configuration: ConfigurationData {
         return configurationProvider.configuration
-    }()
+    }
 
     private func listPlugins() -> Result<[String], Error> {
         let pluginsPaths = Result {


### PR DESCRIPTION
#### Add Injected property wrapper

- `Injected` struct leverages Swift 5.1 property wrapper feature
- Hides `AppAssembly` by wrapping dependency injection logic inside itself.
